### PR TITLE
Add multi select

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This [custom element](https://docs.kontent.ai/tutorials/develop-apps/integrate/i
 - Editors can...
   - Search for products in all languages in the commercetools project
   - Select a single product (or one of it's variants)
+  - Select multiple products (or their variants)
 - Optional debug panel for diagnostics
 
 ## Demo
@@ -34,6 +35,7 @@ The JSON parameters required as as follows:
 | Name     | Type   | Description |
 | -------- | ------ | ----------- |
 | debug    | boolean | (Optional) If present and set to true the debug panel will activate when editing a content item. |
+| multiSelect  | boolean | If set to true, it will be possible to select multiple products. If set to false, it will be possible to only select a single product |
 | commercetools | object | This contains all the details required to connect to the [commercetools API](https://docs.commercetools.com/http-api). The values for this object will be derived from an API client that you configure in commercetools with the exception of the `defaultCulture`. When generating the API client, be sure to select the `view_products` and `view_project_settings` scopes. |
 | commercetools.defaultCulture | string | Set this to the IETF language tag of the language in commercetools to use by default for search. |
 | commercetools.project | string | This is the commercetools project key. |
@@ -48,6 +50,7 @@ Sample parameters JSON:
 ```json
 {
     "debug": true,
+    "multiSelect": true,
     "commercetools": {
         "defaultCulture": "en",
         "project": "your-project",
@@ -62,7 +65,7 @@ Sample parameters JSON:
 
 ## Values saved
 
-The custom element will store the selected product's information in the following format:
+The custom element will store the selected product's information in the following format (In an array):
 
 ```json
 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4969,7 +4969,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4990,12 +4991,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5010,17 +5013,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5137,7 +5143,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5149,6 +5156,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5163,6 +5171,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5170,12 +5179,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5194,6 +5205,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5283,7 +5295,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5295,6 +5308,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5380,7 +5394,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5416,6 +5431,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5435,6 +5451,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5478,12 +5495,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/App.vue
+++ b/src/App.vue
@@ -78,6 +78,7 @@ export default {
       this.updateSize();
     },
     save: function(value) {
+
       // Explicitly using == to match both null and undefined
       const toSave = value == null ? null : JSON.stringify(value);
       this.element.value = toSave;

--- a/src/App.vue
+++ b/src/App.vue
@@ -78,7 +78,6 @@ export default {
       this.updateSize();
     },
     save: function(value) {
-
       // Explicitly using == to match both null and undefined
       const toSave = value == null ? null : JSON.stringify(value);
       this.element.value = toSave;

--- a/src/components/CommercetoolsSelector.vue
+++ b/src/components/CommercetoolsSelector.vue
@@ -1,38 +1,31 @@
 <template>
   <div class="wrapper">
     <ProductSearch
-      v-if="(!value || multiSelect) && !element.disabled"
+      v-if="(!value || value.length == 0 || multiSelect) && !element.disabled"
       :commercetoolsClient="commercetoolsClient"
       @onProductSelected="save"
       :defaultCulture="defaultCulture"
     />
-    <div class="preview" v-if="value && !multiSelect">
-      <PreviewValue
+    <div class="preview" v-if="value">
+      <PreviewValueList
+        v-if="value"
         :value="value"
         :disabled="element.disabled"
-        :multiSelect="true"
+        :multiSelect="multiSelect"
         :commercetoolsClient="commercetoolsClient"
         @onProductCleared="reset"
       />
     </div>
-    <PreviewValueList
-      v-if="value && multiSelect"
-      :value="value"
-      :commercetoolsClient="commercetoolsClient"
-      @onProductCleared="reset"
-    />
   </div>
 </template>
 
 <script>
 import commercetoolsClient from "../helpers/commercetoolsClient";
-import PreviewValue from "./PreviewValue";
 import PreviewValueList from "./PreviewValueList";
 import ProductSearch from "./ProductSearch";
 
 export default {
   components: {
-    PreviewValue,
     ProductSearch,
     PreviewValueList
   },
@@ -64,27 +57,24 @@ export default {
     multiSelect: function() {
       const configAvailable =
         this.element && this.element.config && this.element.config.multiSelect;
-      return configAvailable ? this.element.config.multiSelect : null;
+      return configAvailable ? this.element.config.multiSelect : false;
     }
   },
   methods: {
     reset: function(value) {
-      if (this.multiSelect) {
-        let newValue = this.value ? this.value.filter(x => x.id !== value) : [];
+      let newValue = this.value ? this.value.filter(x => x.id !== value) : [];
 
-        this.$emit("update:value", newValue);
-      } else {
-        this.save(null);
-      }
+      this.$emit("update:value", newValue);
     },
     save: function(value) {
       if (this.element && !this.element.disabled) {
-        if (this.multiSelect) {
-          let newValue = this.value ? [...this.value, value] : [value];
-          this.$emit("update:value", newValue);
-        } else {
-          this.$emit("update:value", value);
-        }
+        const newValue = this.multiSelect
+          ? this.value
+            ? [...this.value, value]
+            : [value]
+          : [value];
+
+        this.$emit("update:value", newValue);
       }
     }
   },

--- a/src/components/CommercetoolsSelector.vue
+++ b/src/components/CommercetoolsSelector.vue
@@ -68,6 +68,11 @@ export default {
     },
     save: function(value) {
       if (this.element && !this.element.disabled) {
+        // Allow the same product to be only selected once
+        if (this.value && this.value.some(x => x.id === value.id)) {
+          return;
+        }
+
         const newValue = this.multiSelect
           ? this.value
             ? [...this.value, value]

--- a/src/components/PreviewValue.vue
+++ b/src/components/PreviewValue.vue
@@ -74,7 +74,11 @@ export default {
 
           this.product = {
             name: "NOT FOUND",
-            variants: []
+            variants: [],
+            masterVariant: {
+              id: 1,
+              images: []
+            }
           };
         }
       }

--- a/src/components/PreviewValue.vue
+++ b/src/components/PreviewValue.vue
@@ -1,16 +1,11 @@
 <template>
-  <div class="preview">
-    <ProductCard
-      v-if="product"
-      :product="product"
-      :variantId="variantId"
-      :culture="culture"
-      @onProductCleared="clearProduct"
-    />
-    <div v-else-if="disabled">
-      No product selected.
-    </div>
-  </div>
+  <ProductCard
+    v-if="product"
+    :product="product"
+    :variantId="variantId"
+    :culture="culture"
+    @onProductCleared="clearProduct"
+  />
 </template>
 
 <script>
@@ -31,6 +26,11 @@ export default {
       validator: prop => typeof prop === "object" || prop === null
     },
     disabled: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    multiSelect: {
       type: Boolean,
       required: false,
       default: false
@@ -68,19 +68,8 @@ export default {
       }
     },
     clearProduct() {
-      this.product = null;
-      this.$emit("onProductCleared");
+      this.$emit("onProductCleared", this.value.id);
     }
   }
 };
 </script>
-
-<style scoped>
-.preview {
-  width: 100%;
-  display: flex;
-  display: -webkit-flex;
-  justify-content: center;
-  -webkit-justify-content: center;
-}
-</style>

--- a/src/components/PreviewValue.vue
+++ b/src/components/PreviewValue.vue
@@ -4,6 +4,7 @@
     :product="product"
     :variantId="variantId"
     :culture="culture"
+    :disabled="disabled"
     @onProductCleared="clearProduct"
   />
 </template>
@@ -26,11 +27,6 @@ export default {
       validator: prop => typeof prop === "object" || prop === null
     },
     disabled: {
-      type: Boolean,
-      required: false,
-      default: false
-    },
-    multiSelect: {
       type: Boolean,
       required: false,
       default: false

--- a/src/components/PreviewValue.vue
+++ b/src/components/PreviewValue.vue
@@ -73,7 +73,7 @@ export default {
           );
 
           this.product = {
-            name: "NOT FOUND",
+            name: { "en-US": "NOT FOUND" },
             variants: [],
             masterVariant: {
               id: 1,

--- a/src/components/PreviewValue.vue
+++ b/src/components/PreviewValue.vue
@@ -56,15 +56,27 @@ export default {
   methods: {
     getCurrentProduct: async function() {
       if (this.value && this.value.id) {
-        logEvent(`Getting product projection for "${this.value.id}"`);
+        try {
+          logEvent(`Getting product projection for "${this.value.id}"`);
 
-        const product = await this.commercetoolsClient.getProductByID({
-          id: this.value.id
-        });
+          const product = await this.commercetoolsClient.getProductByID({
+            id: this.value.id
+          });
 
-        logEvent(`Got product projection for "${this.value.id}"`, product);
+          logEvent(`Got product projection for "${this.value.id}"`, product);
 
-        this.product = product;
+          this.product = product;
+        } catch (e) {
+          logEvent(
+            `Error while getting product projection for "${this.value.id}"`,
+            e
+          );
+
+          this.product = {
+            name: "NOT FOUND",
+            variants: []
+          };
+        }
       }
     },
     clearProduct() {

--- a/src/components/PreviewValueList.vue
+++ b/src/components/PreviewValueList.vue
@@ -1,0 +1,55 @@
+<template>
+  <div>
+    <h3>
+      {{ value.length }} product{{ value.length === 1 ? "" : "s" }} selected
+    </h3>
+
+    <div v-if="value" class="cards">
+      <PreviewValue
+        v-for="product in value"
+        :key="product.id"
+        :value="product"
+        :multiSelect="true"
+        :commercetoolsClient="commercetoolsClient"
+        @onProductCleared="clearProduct"
+      >
+      </PreviewValue>
+    </div>
+  </div>
+</template>
+
+<script>
+import PreviewValue from "./PreviewValue";
+
+export default {
+  components: {
+    PreviewValue
+  },
+  props: {
+    value: {
+      type: Array,
+      required: true
+    },
+    commercetoolsClient: {
+      type: Object,
+      required: false
+    }
+  },
+  methods: {
+    clearProduct: function(payload) {
+      this.$emit("onProductCleared", payload);
+    }
+  }
+};
+</script>
+
+<style scoped>
+.cards {
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  column-gap: 10px;
+  row-gap: 10px;
+  flex-wrap: wrap;
+}
+</style>

--- a/src/components/PreviewValueList.vue
+++ b/src/components/PreviewValueList.vue
@@ -1,6 +1,6 @@
 <template>
-  <div>
-    <h3>
+  <div class="wrapper">
+    <h3 v-if="multiSelect">
       {{ value.length }} product{{ value.length === 1 ? "" : "s" }} selected
     </h3>
 
@@ -9,8 +9,8 @@
         v-for="product in value"
         :key="product.id"
         :value="product"
-        :multiSelect="true"
         :commercetoolsClient="commercetoolsClient"
+        :disabled="disabled"
         @onProductCleared="clearProduct"
       >
       </PreviewValue>
@@ -33,6 +33,16 @@ export default {
     commercetoolsClient: {
       type: Object,
       required: false
+    },
+    multiSelect: {
+      type: Boolean,
+      required: true,
+      default: false
+    },
+    disabled: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
   methods: {
@@ -51,5 +61,9 @@ export default {
   column-gap: 10px;
   row-gap: 10px;
   flex-wrap: wrap;
+}
+
+.wrapper {
+  width: 100%;
 }
 </style>

--- a/src/components/ProductCard.vue
+++ b/src/components/ProductCard.vue
@@ -36,7 +36,7 @@
       </button>
     </div>
 
-    <div class="card__actions" v-if="variantId">
+    <div class="card__actions" v-if="variantId && !disabled">
       <button class="btn btn--primary" @click="clearProduct">
         Clear
       </button>
@@ -59,6 +59,11 @@ export default {
     culture: {
       type: String,
       required: true
+    },
+    disabled: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
   data: () => ({


### PR DESCRIPTION
### Motivation

This feature allows content editors to select multiple products. This can be useful to display a product cluster of hand picked products. 

This was my first encounter with VUE, so bear with me if I did something stupid ;-) 

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

**Multi-select**
- Configure the custom element on a content type. 
- Set the multiSelect property to true
- Create a content item based on the content type
- The product selector should be displayed 
- It should be possible to search and select multiple products
- It should be possible to remove selected products individually

**Single-select**
- Configure the custom element on a content type. 
- Set the multiSelect property to false
- Create a content item based on the content type
- The product selector should be displayed 
- It should be possible to search and select only a single product


